### PR TITLE
Escape primary key where clause

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -416,7 +416,7 @@ Table.prototype.getPrimaryKeyWhereClause = function(key) {
     if (!val && val !== 0) {
       throw new Error('Invalid value specified for "' + self.name + '" primary key.')
     }
-    criteria += iq + self.name + iq + '.' + iq + field + iq + " = '" + val + "'"
+    criteria += iq + self.name + iq + '.' + iq + field + iq + " = " + self.db._query.queryValues(':val', {val})
   })
   return criteria;
 }

--- a/lib/table.js
+++ b/lib/table.js
@@ -416,7 +416,7 @@ Table.prototype.getPrimaryKeyWhereClause = function(key) {
     if (!val && val !== 0) {
       throw new Error('Invalid value specified for "' + self.name + '" primary key.')
     }
-    criteria += iq + self.name + iq + '.' + iq + field + iq + " = " + self.db._query.queryValues(':val', {val})
+    criteria += iq + self.name + iq + '.' + iq + field + iq + " = " + self.db._query.queryValues(':val', {val: val})
   })
   return criteria;
 }


### PR DESCRIPTION
This value may come from the user, so should be escaped.

This was only informally tested as I don't currently have the setup to run the included tests.  

It could be an idea to expose queryValues to the user too.  